### PR TITLE
Fix graceful erroring on invalid template key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,15 @@ notifications:
   email: false
 
 before_install:
-  - gem install bundler
+- gem install bundler
 
-script: bundle exec rspec
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+
+script:
+- bundle exec rspec
+
+after_script: 
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 Rigit
 ==================================================
 
-[![Gem](https://img.shields.io/gem/v/rigit.svg?style=flat-square)](https://rubygems.org/gems/rigit)
-[![Build](https://img.shields.io/travis/DannyBen/rigit.svg?style=flat-square)](https://travis-ci.org/DannyBen/rigit)
-[![Maintainability](https://img.shields.io/codeclimate/maintainability/DannyBen/rigit.svg?style=flat-square)](https://codeclimate.com/github/DannyBen/rigit)
+[![Gem Version](https://badge.fury.io/rb/rigit.svg)](https://badge.fury.io/rb/rigit)
+[![Build Status](https://travis-ci.org/DannyBen/rigit.svg?branch=master)](https://travis-ci.org/DannyBen/rigit)
+[![Maintainability](https://api.codeclimate.com/v1/badges/d13abbe6f7601be78cf5/maintainability)](https://codeclimate.com/github/DannyBen/rigit/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/d13abbe6f7601be78cf5/test_coverage)](https://codeclimate.com/github/DannyBen/rigit/test_coverage)
 
 ---
 

--- a/lib/rigit.rb
+++ b/lib/rigit.rb
@@ -7,6 +7,8 @@ require 'rigit/rig'
 require 'rigit/git'
 require 'rigit/command_line'
 
+require 'byebug' if ENV['BYEBUG']
+
 module Rigit
   module Commands
   end

--- a/lib/rigit/rig.rb
+++ b/lib/rigit/rig.rb
@@ -100,7 +100,7 @@ module Rigit
 
     def get_file_content(file, arguments)
       File.read(file) % arguments
-    rescue ArgumentError => e
+    rescue ArgumentError, KeyError => e
       raise TemplateError.new file, e.message
     end
   end


### PR DESCRIPTION
Invalid `%{keys}` in template files were not rescued correctly, hopefully this fixes it.

In addition:

- We are moving away from shields.io back to native badges due to flakiness issues.
- We now have code coverage config for travis and codeclimate.