### PR TITLE
Feature: add conditional requirements for properties

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -147,6 +147,9 @@
                     },
                     "dependencies": {
                         "list": {
+                            "required": [
+                                "type"
+                            ],
                             "properties": {
                                 "type": {
                                     "const": "select"
@@ -154,6 +157,9 @@
                             }
                         },
                         "code": {
+                            "required": [
+                                "type"
+                            ],
                             "properties": {
                                 "type": {
                                     "const": "ruby"

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "settings",
     "description": "Settings of the current template",
+    "type": "object",
     "properties": {
         "intro": {
             "title": "intro",
@@ -142,6 +143,22 @@
                             "examples": [
                                 "input[:name].upcase"
                             ]
+                        }
+                    },
+                    "dependencies": {
+                        "list": {
+                            "properties": {
+                                "type": {
+                                    "const": "select"
+                                }
+                            }
+                        },
+                        "code": {
+                            "properties": {
+                                "type": {
+                                    "const": "ruby"
+                                }
+                            }
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
- `params.<param>.type` is required to be present when `params.<param>.list` is used
- `params.<param>.type` is required to be `select` when `params.<param>.list` is used
- `params.<param>.type` is required to be present when `params.<param>.code` is used
- `params.<param>.type` is required to be `ruby` when `params.<param>.code` is used

